### PR TITLE
Change `sub` from project URL to (folder-qualified) name

### DIFF
--- a/demo/aws/run.sh
+++ b/demo/aws/run.sh
@@ -91,7 +91,7 @@ cat >/tmp/trust-policy.json <<JSON
     "Action": "sts:AssumeRoleWithWebIdentity",
     "Condition": {
       "StringEquals": {
-        "$host/oidc:sub": "https://$host/job/use-oidc/"
+        "$host/oidc:sub": "use-oidc"
       }
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     </scm>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
+        <hpi.compatibleSinceVersion>25</hpi.compatibleSinceVersion>
         <jenkins.version>2.332.1</jenkins.version>
         <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>

--- a/src/main/java/io/jenkins/plugins/oidc_provider/IdTokenCredentials.java
+++ b/src/main/java/io/jenkins/plugins/oidc_provider/IdTokenCredentials.java
@@ -155,7 +155,7 @@ public abstract class IdTokenCredentials extends BaseStandardCredentials {
             setExpiration(Date.from(new Date().toInstant().plus(1, ChronoUnit.HOURS))).
             setIssuedAt(new Date());
         if (build != null) {
-            builder.setSubject(build.getParent().getAbsoluteUrl()).
+            builder.setSubject(build.getParent().getFullName()).
                 claim("build_number", build.getNumber());
         } else {
             builder.setSubject(Jenkins.get().getRootUrl());

--- a/src/test/java/io/jenkins/plugins/oidc_provider/FolderIssuerTest.java
+++ b/src/test/java/io/jenkins/plugins/oidc_provider/FolderIssuerTest.java
@@ -100,13 +100,13 @@ public class FolderIssuerTest {
         Claims claims = Jwts.parserBuilder().setSigningKey(global.publicKey()).build().parseClaimsJws(b.getAction(EnvironmentAction.class).getEnvironment().get("RESULT")).getBody();
         System.out.println(claims);
         assertEquals(r.getURL() + "oidc", claims.getIssuer());
-        assertEquals(r.getURL() + "job/top/job/middle/job/bottom/job/p/", claims.getSubject());
+        assertEquals("top/middle/bottom/p", claims.getSubject());
         assertEquals("https://global/", claims.getAudience());
         b = r.assertBuildStatusSuccess(p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("CREDS", "team"))));
         claims = Jwts.parserBuilder().setSigningKey(team.publicKey()).build().parseClaimsJws(b.getAction(EnvironmentAction.class).getEnvironment().get("RESULT")).getBody();
         System.out.println(claims);
         assertEquals(r.getURL() + "oidc/job/top/job/middle", claims.getIssuer());
-        assertEquals(p.getAbsoluteUrl(), claims.getSubject());
+        assertEquals("top/middle/bottom/p", claims.getSubject());
         assertEquals("https://local/", claims.getAudience());
     }
 

--- a/src/test/java/io/jenkins/plugins/oidc_provider/IdTokenStringCredentialsTest.java
+++ b/src/test/java/io/jenkins/plugins/oidc_provider/IdTokenStringCredentialsTest.java
@@ -66,7 +66,7 @@ public class IdTokenStringCredentialsTest {
             getBody();
         System.out.println(claims);
         assertEquals(r.jenkins.getRootUrl() + "oidc", claims.getIssuer());
-        assertEquals(p.getAbsoluteUrl(), claims.getSubject());
+        assertEquals("p", claims.getSubject());
         assertEquals("https://service/", claims.getAudience());
         assertEquals(1, claims.get("build_number", Integer.class).intValue());
     }
@@ -118,7 +118,7 @@ public class IdTokenStringCredentialsTest {
             getBody();
         System.out.println(claims);
         assertEquals("https://some.issuer", claims.getIssuer());
-        assertEquals(p.getAbsoluteUrl(), claims.getSubject());
+        assertEquals("p", claims.getSubject());
     }
 
 }


### PR DESCRIPTION
https://github.com/jenkinsci/oidc-provider-plugin/issues/14#issuecomment-1212069213

Under discussion what this should ultimately be. Possibly `IdTokenCredentials` could just have a format field where you could insert the project URL, full name, or various claims as you preferred.