### PR TITLE
Set cache header for JWKS response

### DIFF
--- a/src/main/java/io/jenkins/plugins/oidc_provider/Keys.java
+++ b/src/main/java/io/jenkins/plugins/oidc_provider/Keys.java
@@ -38,6 +38,7 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 /**
  * Serves OIDC definition and JWKS.
@@ -56,7 +57,7 @@ import org.kohsuke.stapler.StaplerRequest2;
         return URL_NAME;
     }
 
-    public JSONObject doDynamic(StaplerRequest2 req) {
+    public JSONObject doDynamic(StaplerRequest2 req, StaplerResponse2 res) {
         String path = req.getOriginalRestOfPath();
         try (ACLContext context = ACL.as2(ACL.SYSTEM2)) { // both forUri and credentials might check permissions
             Issuer i = findIssuer(path, WELL_KNOWN_OPENID_CONFIGURATION);
@@ -75,6 +76,7 @@ import org.kohsuke.stapler.StaplerRequest2;
                         }
                         keys.element(key(creds));
                     }
+                    res.setHeader("Cache-Control", "no-cache");
                     return new JSONObject().accumulate("keys", keys);
                 }
             }

--- a/src/test/java/io/jenkins/plugins/oidc_provider/KeysTest.java
+++ b/src/test/java/io/jenkins/plugins/oidc_provider/KeysTest.java
@@ -97,6 +97,7 @@ public class KeysTest {
         assertEquals(r.getURL() + "oidc", config.getString("issuer"));
         JenkinsRule.WebClient wc = r.createWebClient();
         Page p = wc.getPage(new URL(config.getString("jwks_uri")));
+        assertEquals("no-cache", p.getWebResponse().getResponseHeaderValue("Cache-Control"));
         assertEquals("application/json", p.getWebResponse().getContentType());
         JSONObject jwks = JSONObject.fromObject(p.getWebResponse().getContentAsString());
         System.err.println(jwks.toString(2));


### PR DESCRIPTION
Basically doing https://github.com/jenkinsci/oidc-provider-plugin/issues/66

It works very well util keys are rotated (it looks it happen each time JCasC is reloaded).

Previous ID token still get exchanged, but new ID token fail their signature.

My gut is that Artifactory is doing exessive caching of JWKS keys and doesn't get keys

I was trying to compare with other OIDC provider (Keycloak) and they seems to set the `Cache`

![keycloak](https://github.com/user-attachments/assets/1607d269-bb5c-4725-9401-825fdac4f0d4)

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

