### PR TITLE
Add support for GIT_URL, GIT_BRANCH and GIT_COMMIT in claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ You can add claims to all id tokens, those used during builds,
 or those used outside of builds (for example by other Jenkins plugins accepting string credentials).
 All applicable kinds of claim templates will be merged.
 
+### Using SCM information in claims
+
+If your build uses Git SCM (Source Code Management), you can include Git-related information in your id token claims.
+The following variables are available:
+
+* `${GIT_URL}` - The URL of the Git repository (e.g., `https://github.com/user/repo.git`)
+* `${GIT_BRANCH}` - The branch reference being built (e.g., `origin/master`, `upstream/main`, or `master`)
+* `${GIT_COMMIT}` - The commit SHA being built (e.g., `abc123def456...`)
+
+These variables can be used in claim templates, for example:
+
+```
+git_repository: ${GIT_URL}
+git_branch: ${GIT_BRANCH}
+git_sha: ${GIT_COMMIT}
+```
+
+**How it works:**
+
+* Git information is extracted from `BuildData` actions created by the Git plugin during checkout
+* For **Declarative Pipeline jobs**: Git checkout happens automatically before stages, so variables are available immediately
+* For **Scripted Pipeline jobs**: Use explicit `checkout scm` before calling `withCredentials`
+* For **Freestyle jobs**: Git checkout in build step populates `BuildData` automatically
+
 ## Examples
 
 Some tested usage examples follow. Please contribute others!

--- a/src/main/java/io/jenkins/plugins/oidc_provider/IdTokenCredentials.java
+++ b/src/main/java/io/jenkins/plugins/oidc_provider/IdTokenCredentials.java
@@ -48,6 +48,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.KeyFactory;
@@ -273,6 +274,11 @@ public abstract class IdTokenCredentials extends BaseStandardCredentials {
                 envs.add(env);
             }
         }
+
+        var scmEnv = extractGitInfoFromBuildData(build, listener);
+        if (!scmEnv.isEmpty()) {
+            envs.add(scmEnv);
+        }
         var merged = new EnvVars();
         envs.stream().flatMap(env -> env.entrySet().stream()).collect(Collectors.groupingBy(Map.Entry::getKey)).entrySet().stream().forEach(entry -> {
             var values = entry.getValue().stream().map(Map.Entry::getValue).collect(Collectors.toSet());
@@ -283,6 +289,94 @@ public abstract class IdTokenCredentials extends BaseStandardCredentials {
             }
         });
         return merged;
+    }
+
+    private static EnvVars extractGitInfoFromBuildData(Run<?, ?> build, TaskListener listener) {
+        var env = new EnvVars();
+        Object buildData = null;
+        
+        for (var action : build.getActions()) {
+            if (action.getClass().getName().equals("hudson.plugins.git.util.BuildData")) {
+                if (buildData == null) {
+                    buildData = action;
+                }
+                
+                try {
+                    Method getScmName = action.getClass().getMethod("getScmName");
+                    String scmName = (String) getScmName.invoke(action);
+                    if (scmName == null || scmName.isEmpty()) {
+                        buildData = action;
+                        break;
+                    }
+                } catch (Exception e) {
+                    LOGGER.log(Level.FINEST, "Could not determine scmName from BuildData", e);
+                }
+            }
+        }
+        
+        if (buildData != null) {
+            try {
+                extractGitCommit(buildData, env);
+                extractGitBranch(buildData, env);
+                extractGitUrl(buildData, env);
+            } catch (Exception e) {
+                LOGGER.log(Level.FINE, "Could not extract Git information from BuildData action", e);
+            }
+        }
+        
+        return env;
+    }
+
+    private static void extractGitCommit(Object buildData, EnvVars env) throws Exception {
+        Method getLastBuiltRevision = buildData.getClass().getMethod("getLastBuiltRevision");
+        Object revision = getLastBuiltRevision.invoke(buildData);
+        if (revision != null) {
+            Method getSha1String = revision.getClass().getMethod("getSha1String");
+            String commit = (String) getSha1String.invoke(revision);
+            if (commit != null && !commit.isEmpty()) {
+                env.put("GIT_COMMIT", commit);
+            }
+        }
+    }
+
+    private static void extractGitBranch(Object buildData, EnvVars env) throws Exception {
+        Method getLastBuiltRevision = buildData.getClass().getMethod("getLastBuiltRevision");
+        Object revision = getLastBuiltRevision.invoke(buildData);
+        if (revision == null) {
+            return;
+        }
+
+        Method getBranches = revision.getClass().getMethod("getBranches");
+        @SuppressWarnings("unchecked")
+        java.util.Set<?> branches = (java.util.Set<?>) getBranches.invoke(revision);
+        if (branches == null || branches.isEmpty()) {
+            return;
+        }
+
+        Object branch = branches.iterator().next();
+        Method getName = branch.getClass().getMethod("getName");
+        String branchName = (String) getName.invoke(branch);
+        if (branchName == null || branchName.isEmpty()) {
+            return;
+        }
+
+        if (branchName.startsWith("refs/remotes/")) {
+            branchName = branchName.substring("refs/remotes/".length());
+        }
+        
+        env.put("GIT_BRANCH", branchName);
+    }
+
+    private static void extractGitUrl(Object buildData, EnvVars env) throws Exception {
+        Method getRemoteUrls = buildData.getClass().getMethod("getRemoteUrls");
+        @SuppressWarnings("unchecked")
+        java.util.Set<?> remoteUrls = (java.util.Set<?>) getRemoteUrls.invoke(buildData);
+        if (remoteUrls != null && !remoteUrls.isEmpty()) {
+            String url = remoteUrls.iterator().next().toString();
+            if (url != null && !url.isEmpty()) {
+                env.put("GIT_URL", url);
+            }
+        }
     }
 
     protected @NonNull Issuer findIssuer() {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

The additions in this PR makes Git SCM information (repository URL, branch, commit) available as variables in OIDC token claims.

Instead of relying on potentially tainted env vars, Git information is extracted from `hudson.plugins.git.util.BuildData` actions that are created by the Git plugin during checkout. It follows the Git plugin's environment variable naming conventions:

| Variable | Example | Notes |
|--|---|--|
| `GIT_URL` | `https://github.com/user/repo.git` | From `BuildData.getRemoteUrls()` |
| `GIT_BRANCH` | `origin/master`, `upstream/main`, or `master` | From `BuildData.getBranches().getName()` |
| `GIT_COMMIT` | `abc123def456...` | From `BuildData.getLastBuiltRevision()` |

The variables will be empty (not replaced) if no Git checkout has occurred or if Git plugin data is not available. 

### Implementation Details

* Using reflection to call `BuildData` methods avoids a hard dependency on the Git plugin
* The process is roughly like this:
  * Iterate through build actions looking for `hudson.plugins.git.util.BuildData`
  * Identify primary `BuildData` (workspace checkout) via `scmName == null` or empty
    * The reasoning here is that in multibranch pipelines, the workspace checkout (primary) has no `scmName` and that this is typically what users expect for security policies (not additional checkouts)
  * Use primary `BuildData` if found, otherwise use first `BuildData` (in fact only relevant if multiple SCMs are used)
  * Extract information via helper methods:
    * **extractGitCommit**: Gets `GIT_COMMIT` from `getLastBuiltRevision().getSha1String()`
    * **extractGitBranch**: Gets `GIT_BRANCH`, strips `refs/remotes/` prefix (analogous to what is done in [GitSCM.java](https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/hudson/plugins/git/GitSCM.java)
    * **extractGitUrl**: Gets `GIT_URL` from `getRemoteUrls()`

Resolves:
- https://github.com/jenkinsci/oidc-provider-plugin/issues/43.

### Testing done

- Using a local demo setup, I verified that it works for **all job types** (freestyle, declarative pipelines, scripted pipelines) and that the desired values are actually inserted into claims.
- The implementation prevents the fake value injection ([SECURITY-3574](https://www.jenkins.io/security/advisory/2025-05-14/#SECURITY-3574)) as it doesn't rely on environment vars. If multiple sources provide conflicting values, the token generation will detect the conflict and refuse to use the tainted value.
- I've also tested whether it could be possible to "break" the JWT e.g., using a branch name like `inj"ection` but found that this is correctly escaped in the output (and, in theory, would impact the Git plugin likewise).

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
