### PR TITLE
Adapt to `jjwt-api` 0.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>jjwt-api</artifactId>
-                <version>0.13.0-139.vb_dc6c7b_b_1ea_9</version>
+                <version>0.13.0-141.vd58b_a_9592b_6c</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- TODO https://github.com/jenkinsci/jjwt-api-plugin/pull/124 -->
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>jjwt-api</artifactId>
+                <version>0.13.0-139.vb_dc6c7b_b_1ea_9</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <repositories>

--- a/src/main/java/io/jenkins/plugins/oidc_provider/IdTokenCredentials.java
+++ b/src/main/java/io/jenkins/plugins/oidc_provider/IdTokenCredentials.java
@@ -47,6 +47,7 @@ import hudson.util.Secret;
 import io.jenkins.plugins.oidc_provider.config.ClaimTemplate;
 import io.jenkins.plugins.oidc_provider.config.IdTokenConfiguration;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ClaimsMutator;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import java.io.IOException;
@@ -203,13 +204,15 @@ public abstract class IdTokenCredentials extends BaseStandardCredentials {
 
     protected final @NonNull String token() {
         IdTokenConfiguration cfg = IdTokenConfiguration.get();
-        JwtBuilder builder = Jwts.builder().
-            setHeaderParam("kid", getId()).
-            setHeaderParam("typ", "JWT").
-            setIssuer(issuer != null ? issuer : findIssuer().url()).
-            setAudience(audience).
-            setExpiration(Date.from(Instant.now().plus(cfg.getTokenLifetime(), ChronoUnit.SECONDS))).
-            setIssuedAt(new Date());
+        var iat = Instant.now();
+        var exp = iat.plus(cfg.getTokenLifetime(), ChronoUnit.SECONDS);
+        JwtBuilder builder = Jwts.builder().header().
+            add("kid", getId()).
+            add("typ", "JWT").and().
+            issuer(issuer != null ? issuer : findIssuer().url()).
+            audience().add(audience).and().
+            issuedAt(Date.from(iat)).
+            expiration(Date.from(exp));
         Map<String, String> env;
         if (build != null) {
             try {

--- a/src/test/java/io/jenkins/plugins/oidc_provider/FolderIssuerTest.java
+++ b/src/test/java/io/jenkins/plugins/oidc_provider/FolderIssuerTest.java
@@ -44,6 +44,8 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.actions.EnvironmentAction;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -112,16 +114,16 @@ class FolderIssuerTest {
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("CREDS")));
         p.setDefinition(new CpsFlowDefinition("withCredentials([string(variable: 'ID_TOKEN', credentialsId: CREDS)]) {env.RESULT = ID_TOKEN}", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("CREDS", "global"))));
-        Claims claims = Jwts.parserBuilder().setSigningKey(global.publicKey()).build().parseClaimsJws(b.getAction(EnvironmentAction.class).getEnvironment().get("RESULT")).getBody();
+        var claims = Jwts.parser().verifyWith(global.publicKey()).build().parseSignedClaims(b.getAction(EnvironmentAction.class).getEnvironment().get("RESULT")).getPayload();
         System.out.println(claims);
         assertEquals(r.getURL() + "oidc", claims.getIssuer());
         assertEquals(r.getURL() + "job/at%20the%20top/job/middle/job/bottom/job/p/", claims.getSubject());
-        assertEquals("https://global/", claims.getAudience());
+        assertThat(claims.getAudience(), contains("https://global/"));
         b = r.assertBuildStatusSuccess(p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("CREDS", "team"))));
-        claims = Jwts.parserBuilder().setSigningKey(team.publicKey()).build().parseClaimsJws(b.getAction(EnvironmentAction.class).getEnvironment().get("RESULT")).getBody();
+        claims = Jwts.parser().verifyWith(team.publicKey()).build().parseSignedClaims(b.getAction(EnvironmentAction.class).getEnvironment().get("RESULT")).getPayload();
         System.out.println(claims);
         assertEquals(r.getURL() + "oidc/job/at%20the%20top/job/middle", claims.getIssuer());
         assertEquals(p.getAbsoluteUrl(), claims.getSubject());
-        assertEquals("https://local/", claims.getAudience());
+        assertThat(claims.getAudience(), contains("https://local/"));
     }
 }

--- a/src/test/java/io/jenkins/plugins/oidc_provider/IdTokenCredentialsTest.java
+++ b/src/test/java/io/jenkins/plugins/oidc_provider/IdTokenCredentialsTest.java
@@ -167,11 +167,11 @@ class IdTokenCredentialsTest {
             cfg.setTokenLifetime(60);
             String idToken = c.getSecret().getPlainText();
             System.out.println(idToken);
-            Claims claims = Jwts.parserBuilder().
-                setSigningKey(c.publicKey()).
+            var claims = Jwts.parser().
+                verifyWith(c.publicKey()).
                 build().
-                parseClaimsJws(idToken).
-                getBody();
+                parseSignedClaims(idToken).
+                getPayload();
 
             assertTrue(Instant.now().plus(61, ChronoUnit.SECONDS).isAfter(claims.getExpiration().toInstant()));
         });
@@ -188,11 +188,11 @@ class IdTokenCredentialsTest {
             cfg.setBuildClaimTemplates(Arrays.asList(new ClaimTemplate("sub", "${JOB_NAME}", new StringClaimType()), new ClaimTemplate("num", "${BUILD_NUMBER}", new IntegerClaimType())));
             String idToken = c.getSecret().getPlainText();
             System.out.println(idToken);
-            Claims claims = Jwts.parserBuilder().
-                setSigningKey(c.publicKey()).
+            var claims = Jwts.parser().
+                verifyWith(c.publicKey()).
                 build().
-                parseClaimsJws(idToken).
-                getBody();
+                parseSignedClaims(idToken).
+                getPayload();
             System.out.println(claims);
             assertEquals(r.jenkins.getRootUrl() + "oidc", claims.getIssuer());
             assertEquals("jenkins", claims.getSubject());
@@ -203,11 +203,11 @@ class IdTokenCredentialsTest {
             EnvironmentAction env = b.getAction(EnvironmentAction.class);
             idToken = env.getEnvironment().get("TOK");
             System.out.println(idToken);
-            claims = Jwts.parserBuilder().
-                setSigningKey(c.publicKey()).
+            claims = Jwts.parser().
+                verifyWith(c.publicKey()).
                 build().
-                parseClaimsJws(idToken).
-                getBody();
+                parseSignedClaims(idToken).
+                getPayload();
             System.out.println(claims);
             assertEquals(r.jenkins.getRootUrl() + "oidc", claims.getIssuer());
             assertEquals("dir/p", claims.getSubject());

--- a/src/test/java/io/jenkins/plugins/oidc_provider/IdTokenFileCredentialsTest.java
+++ b/src/test/java/io/jenkins/plugins/oidc_provider/IdTokenFileCredentialsTest.java
@@ -79,11 +79,11 @@ class IdTokenFileCredentialsTest {
         assertNotNull(env);
         String idToken = env.getEnvironment().get("RESULT");
         assertNotNull(idToken);
-        Claims claims = Jwts.parserBuilder().
-            setSigningKey(c.publicKey()).
+        var claims = Jwts.parser().
+            verifyWith(c.publicKey()).
             build().
-            parseClaimsJws(idToken).
-            getBody();
+            parseSignedClaims(idToken).
+            getPayload();
         assertEquals(r.jenkins.getRootUrl() + "oidc", claims.getIssuer());
     }
 
@@ -111,11 +111,11 @@ class IdTokenFileCredentialsTest {
             "}", true));
         WorkflowRun b = r.buildAndAssertSuccess(p);
         String idToken = s.getWorkspaceFor(p).child("tok").readToString();
-        Claims claims = Jwts.parserBuilder().
-            setSigningKey(c.publicKey()).
+        var claims = Jwts.parser().
+            verifyWith(c.publicKey()).
             build().
-            parseClaimsJws(idToken).
-            getBody();
+            parseSignedClaims(idToken).
+            getPayload();
         System.out.println(claims);
     }
 }

--- a/src/test/java/io/jenkins/plugins/oidc_provider/IdTokenStringCredentialsTest.java
+++ b/src/test/java/io/jenkins/plugins/oidc_provider/IdTokenStringCredentialsTest.java
@@ -31,6 +31,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -74,12 +75,12 @@ class IdTokenStringCredentialsTest {
         String idToken = env.getEnvironment().get("RESULT");
         assertNotNull(idToken);
         System.out.println(idToken);
-        var jws = Jwts.parserBuilder().
-            setSigningKey(c.publicKey()).
+        var jws = Jwts.parser().
+            verifyWith(c.publicKey()).
             build().
-            parseClaimsJws(idToken);
+            parseSignedClaims(idToken);
         var header = jws.getHeader();
-        var claims = jws.getBody();
+        var claims = jws.getPayload();
         System.out.println(header);
         assertThat(header.getKeyId(), is("test"));
         assertThat(header.getAlgorithm(), is("RS256"));
@@ -87,7 +88,7 @@ class IdTokenStringCredentialsTest {
         System.out.println(claims);
         assertEquals(r.jenkins.getRootUrl() + "oidc", claims.getIssuer());
         assertEquals(p.getAbsoluteUrl(), claims.getSubject());
-        assertEquals("https://service/", claims.getAudience());
+        assertThat(claims.getAudience(), contains("https://service/"));
         assertEquals(1, claims.get("build_number", Integer.class).intValue());
     }
 
@@ -112,11 +113,11 @@ class IdTokenStringCredentialsTest {
             "}", true));
         WorkflowRun b = r.buildAndAssertSuccess(p);
         String idToken = r.jenkins.getWorkspaceFor(p).child("tok").readToString();
-        Claims claims = Jwts.parserBuilder().
-            setSigningKey(c.publicKey()).
+        var claims = Jwts.parser().
+            verifyWith(c.publicKey()).
             build().
-            parseClaimsJws(idToken).
-            getBody();
+            parseSignedClaims(idToken).
+            getPayload();
         System.out.println(claims);
         assertEquals(1, claims.get("build_number", Integer.class).intValue());
     }
@@ -133,11 +134,11 @@ class IdTokenStringCredentialsTest {
         assertNotNull(env);
         String idToken = env.getEnvironment().get("RESULT");
         assertNotNull(idToken);
-        Claims claims = Jwts.parserBuilder().
-            setSigningKey(c.publicKey()).
+        var claims = Jwts.parser().
+            verifyWith(c.publicKey()).
             build().
-            parseClaimsJws(idToken).
-            getBody();
+            parseSignedClaims(idToken).
+            getPayload();
         System.out.println(claims);
         assertEquals("https://some.issuer", claims.getIssuer());
         assertEquals(p.getAbsoluteUrl(), claims.getSubject());


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/jjwt-api-plugin/pull/124. It is possible, though very awkward, to make `src/main/java/` (JWT generation) compile against 0.11.5 but also link against 0.13.0 (various deprecated methods changed binary signature); but it is not possible to do the same for `src/test/java/` (JWT validation) without using reflection.