### PR TITLE
Demonstration that `GIT_COMMIT` can be bound in a claim template

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 17],
+    [platform: 'linux', jdk: 25],
     [platform: 'windows', jdk: 21],
 ])

--- a/consume-incrementals
+++ b/consume-incrementals
@@ -1,0 +1,1 @@
+https://github.com/jenkinsci/workflow-job-plugin/pull/786

--- a/consume-incrementals
+++ b/consume-incrementals
@@ -1,1 +1,0 @@
-https://github.com/jenkinsci/workflow-job-plugin/pull/786

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-job</artifactId>
-                <version>1592.va_c6b_e29dc070</version>
+                <version>1595.v0ee1a_de2c0a_3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
     </scm>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.541</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <jenkins.baseline>2.568</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
         <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
+        <banObsoleteDependencyOverrides.skip>false</banObsoleteDependencyOverrides.skip>
     </properties>
     <dependencies>
         <dependency>
@@ -93,21 +93,37 @@
             <version>4.3.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>6210.v69ea_fd8a_f010</version>
+                <version>6641.vfe1b_b_3c48a_4a_</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- TODO https://github.com/jenkinsci/jjwt-api-plugin/pull/124 -->
             <dependency>
-                <groupId>io.jenkins.plugins</groupId>
-                <artifactId>jjwt-api</artifactId>
-                <version>0.13.0-141.vd58b_a_9592b_6c</version>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-job</artifactId>
+                <version>1592.va_c6b_e29dc070</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/test/java/io/jenkins/plugins/oidc_provider/ScmClaimsTest.java
+++ b/src/test/java/io/jenkins/plugins/oidc_provider/ScmClaimsTest.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.jenkins.plugins.oidc_provider;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
+import io.jenkins.plugins.oidc_provider.config.ClaimTemplate;
+import io.jenkins.plugins.oidc_provider.config.IdTokenConfiguration;
+import io.jenkins.plugins.oidc_provider.config.StringClaimType;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.util.List;
+import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.junit.jupiter.WithGitSampleRepo;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.support.actions.EnvironmentAction;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.BuildWatcherExtension;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@WithJenkins
+@WithGitSampleRepo
+final class ScmClaimsTest {
+
+    @RegisterExtension
+    private static final BuildWatcherExtension BUILD_WATCHER = new BuildWatcherExtension();
+
+    @Test void bound(JenkinsRule j, GitSampleRepoRule repo) throws Exception {
+        repo.init();
+        repo.write("f", "content");
+        repo.git("add", "f");
+        repo.git("commit", "--message=stuff");
+        var commit = repo.head();
+        IdTokenConfiguration.get().setBuildClaimTemplates(List.of(new ClaimTemplate(Claims.SUBJECT, "${JOB_URL}", new StringClaimType()), new ClaimTemplate("commit_hash", "${GIT_COMMIT}", new StringClaimType())));
+        var c = new IdTokenStringCredentials(CredentialsScope.GLOBAL, "test", null);
+        CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), c);
+        var p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("""
+            node {
+              git REPO
+              withCredentials([string(variable: 'TOK', credentialsId: 'test')]) {
+                env.TOK = TOK
+              }
+            }
+            """, true));
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("REPO")));
+        var b = p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("REPO", repo.toString()))).get();
+        j.assertBuildStatusSuccess(b);
+        var idToken = b.getAction(EnvironmentAction.class).getEnvironment().get("TOK");
+        System.out.println(idToken);
+        var claims = Jwts.parser().
+                verifyWith(c.publicKey()).
+                build().
+                parseSignedClaims(idToken).
+                getPayload();
+        System.out.println(claims);
+        assertThat(claims.get("commit_hash", String.class), is(commit));
+    }
+
+}


### PR DESCRIPTION
Fixes #43. Closes #200. Downstream of https://github.com/jenkinsci/workflow-job-plugin/pull/786.